### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test-template:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/retr0crypticghost/python-template/security/code-scanning/1](https://github.com/retr0crypticghost/python-template/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow or job definition. Since there is only one job (`test-template`) in this workflow, and nothing in the steps appears to require write access (no steps that create issues, PRs, or push changes), we can safely and minimally assign `contents: read` permissions, which is the lowest privilege that allows source code read actions such as `actions/checkout`. The `permissions` block should be inserted either directly within the job definition (recommended for a single job workflow like this) or at the root of the workflow if you want all jobs to inherit these permissions by default. The single best way to fix this is to add the following under the job definition (`test-template: ...`), above `runs-on: ubuntu-latest`, like so:

```yaml
test-template:
  permissions:
    contents: read
  runs-on: ubuntu-latest
```

No additional imports or dependencies are required; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
